### PR TITLE
Adding vagrant to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.DS_Store
+Vagrantfile
+.vagrant/


### PR DESCRIPTION
I am starting to put together the tools needed to test the saltopenstack code by testing locally via vagrant.  This PR is to include the Vagrantfile and the .vagrant/ directory to the .gitignore file.
